### PR TITLE
feat: bootstrap static skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Neuromorphs Playground
+
+Neuromorphs is a zero-build browser playground for evolving virtual creatures. The initial project skeleton
+runs entirely from static HTML, CSS, and JavaScript files served from the repository root. Future phases will
+layer in physics workers, genome schemas, evolutionary loops, and UI tooling.
+
+## Quickstart
+
+1. **Install prerequisites**: Any modern browser (Chrome 120+, Firefox 120+, Safari 17+) and Python 3.10+ for
+   the ad-hoc dev server.
+2. **Start a local server** from the project root:
+
+   ```bash
+   python3 -m http.server 8080
+   ```
+
+3. **Open the playground** at [http://localhost:8080/index.html](http://localhost:8080/index.html).
+4. **Verify the placeholder scene**: A glowing cube should spin inside the canvas, and the status message should
+   confirm that Three.js and Rapier initialized successfully.
+
+## Project Layout
+
+```
+index.html         # Entry point that wires up CDN ESM modules
+style.css          # Global site styling (dark/light friendly)
+public/app.js      # App orchestration and placeholder Three.js + Rapier init
+```
+
+Additional modules will live under `public/` (UI panels, render helpers) and worker scripts under `workers/`
+as the plan advances to later phases.
+
+## CDN Dependencies
+
+- [Three.js](https://threejs.org/) via jsDelivr ESM bundle
+- [Rapier 3D Compat](https://rapier.rs/) WebAssembly build via jsDelivr
+
+Both dependencies load at runtime through native ES Module imports inside `public/app.js`, so no bundler or
+transpilation step is required.
+
+## Browser Support
+
+The project targets evergreen browsers with native ES Module and WebAssembly support. SharedArrayBuffer features
+may require running the dev server with COOP/COEP headers in later phases; instructions will be added once those
+features land.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Neuromorphs Playground</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <h1>Neuromorphs Playground</h1>
+      <p class="tagline">Procedural creatures evolved in your browser.</p>
+    </header>
+    <main class="content">
+      <section class="viewport-panel">
+        <canvas id="viewport" aria-label="Creature preview" role="img"></canvas>
+        <p class="status" id="status-message">Loading WebGL and physics modules…</p>
+      </section>
+      <section class="info-panel">
+        <h2>Welcome</h2>
+        <p>
+          The project skeleton is ready. Three.js renders a placeholder cube and Rapier’s WebAssembly
+          bundle initializes in the background. Future phases will swap this message with real evolution
+          controls and analytics.
+        </p>
+        <button id="action-button" type="button">Pause Spin</button>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <small>
+        Serve this directory with <code>python3 -m http.server 8080</code> and open
+        <code>http://localhost:8080/index.html</code> to explore the prototype.
+      </small>
+    </footer>
+    <script type="module" src="./public/app.js"></script>
+  </body>
+</html>

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,104 @@
+import {
+  AmbientLight,
+  BoxGeometry,
+  Clock,
+  Color,
+  DirectionalLight,
+  Mesh,
+  MeshStandardMaterial,
+  PerspectiveCamera,
+  Scene,
+  Vector3,
+  WebGLRenderer
+} from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
+import RAPIER from 'https://cdn.jsdelivr.net/npm/@dimforge/rapier3d-compat@0.11.2/rapier3d-compat.es.js';
+
+const canvas = document.querySelector('#viewport');
+const statusMessage = document.querySelector('#status-message');
+const actionButton = document.querySelector('#action-button');
+
+if (!canvas) {
+  throw new Error('Viewport canvas not found.');
+}
+
+const renderer = new WebGLRenderer({
+  canvas,
+  antialias: true,
+  alpha: true
+});
+renderer.setPixelRatio(window.devicePixelRatio);
+
+const scene = new Scene();
+scene.background = new Color('#020617');
+
+const camera = new PerspectiveCamera(45, 1, 0.1, 100);
+camera.position.set(4, 3, 6);
+camera.lookAt(new Vector3(0, 0, 0));
+
+const ambient = new AmbientLight('#e2e8f0', 0.6);
+const keyLight = new DirectionalLight('#60a5fa', 0.8);
+keyLight.position.set(5, 6, 4);
+const fillLight = new DirectionalLight('#f472b6', 0.3);
+fillLight.position.set(-4, 2, -5);
+scene.add(ambient, keyLight, fillLight);
+
+const geometry = new BoxGeometry(1.5, 1, 1.5);
+const material = new MeshStandardMaterial({
+  color: '#38bdf8',
+  roughness: 0.35,
+  metalness: 0.1
+});
+const cube = new Mesh(geometry, material);
+scene.add(cube);
+
+const clock = new Clock();
+let spinning = true;
+
+function resize() {
+  const width = canvas.clientWidth;
+  const height = canvas.clientHeight;
+  if (width === 0 || height === 0) {
+    return;
+  }
+  camera.aspect = width / height;
+  camera.updateProjectionMatrix();
+  renderer.setSize(width, height, false);
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+function render() {
+  const delta = clock.getDelta();
+  if (spinning) {
+    cube.rotation.y += delta * 0.8;
+    cube.rotation.x += delta * 0.4;
+  }
+  renderer.render(scene, camera);
+  requestAnimationFrame(render);
+}
+
+requestAnimationFrame(render);
+
+actionButton?.addEventListener('click', () => {
+  spinning = !spinning;
+  actionButton.textContent = spinning ? 'Pause Spin' : 'Resume Spin';
+});
+
+async function initPhysics() {
+  try {
+    statusMessage.textContent = 'Initializing Rapier physics…';
+    await RAPIER.init();
+    const gravity = new RAPIER.Vector3(0, -9.81, 0);
+    const world = new RAPIER.World(gravity);
+    statusMessage.textContent = 'Three.js and Rapier are ready. Placeholder cube is spinning!';
+    console.info('Rapier world created with gravity', world.gravity);
+    // Clean up temporary world until physics worker lands.
+    world.free();
+  } catch (error) {
+    console.error('Failed to load Rapier', error);
+    statusMessage.textContent = 'Failed to initialize physics. Check the console for details.';
+  }
+}
+
+initPhysics();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,113 @@
+:root {
+  color-scheme: dark light;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background-color: #0d1117;
+  color: #e6edf3;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.site-header,
+.site-footer {
+  padding: 1.5rem;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.1), rgba(14, 165, 233, 0.05));
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.site-footer {
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  border-bottom: none;
+  text-align: center;
+}
+
+h1,
+h2 {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.tagline {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.content {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 1.5rem;
+  padding: 1.5rem;
+  flex: 1;
+}
+
+.viewport-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 1rem;
+  min-height: 360px;
+}
+
+#viewport {
+  width: 100%;
+  height: 100%;
+  flex: 1;
+  border-radius: 12px;
+  background: radial-gradient(circle at 50% 50%, rgba(96, 165, 250, 0.2), rgba(15, 23, 42, 0.9));
+}
+
+.status {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.info-panel {
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+button {
+  align-self: flex-start;
+  padding: 0.65rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #38bdf8, #2563eb);
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.35);
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 40px rgba(56, 189, 248, 0.45);
+}
+
+button:active {
+  transform: translateY(0);
+  box-shadow: 0 6px 20px rgba(37, 99, 235, 0.5);
+}
+
+@media (max-width: 900px) {
+  .content {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add an index.html shell that links CDN-delivered modules and base styling
- spin up a placeholder Three.js scene with Rapier initialization in public/app.js
- document the zero-build workflow and project layout in a new README

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68dd65f0b0a88323bfe7c71923179063