### PR TITLE
feat: run rapier drop test in worker

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -28,24 +28,25 @@
 ---
 
 ## Phase 1 — Physics Core (CDN Rapier + Worker)
-- [ ] **P1-01: Load Rapier WASM from CDN**
+- [x] **P1-01: Load Rapier WASM from CDN**
   - **Owner:** Physics Agent
   - **Inputs:** `@dimforge/rapier3d-compat` CDN
   - **Outputs:** WASM initialized in Worker
   - **DoD:** Cube drop test shows gravity in console
   - **Dependencies:** P0-02
-- [ ] **P1-02: Worker Script with ES Modules**
+- [x] **P1-02: Worker Script with ES Modules**
   - **Owner:** Physics Agent
   - **Inputs:** `worker.js` as module worker
   - **Outputs:** Stepper running physics loop
   - **DoD:** Logs position updates from Worker
   - **Dependencies:** P1-01
-- [ ] **P1-03: Shared Memory Protocol (optional)**  
+- [ ] **P1-03: Shared Memory Protocol (optional)**
   - **Owner:** Platform Agent
   - **Inputs:** SharedArrayBuffer via COOP/COEP headers (local server required)
   - **Outputs:** Snapshot arrays passed from worker to main
   - **DoD:** Renderer reads transforms without blocking
   - **Dependencies:** P1-02
+  - **Status:** Deferred until cross-origin isolation is required.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -19,11 +19,11 @@
       <section class="info-panel">
         <h2>Welcome</h2>
         <p>
-          The project skeleton is ready. Three.js renders a placeholder cube and Rapier’s WebAssembly
-          bundle initializes in the background. Future phases will swap this message with real evolution
-          controls and analytics.
+          The physics core now runs inside a dedicated Web Worker. Rapier’s WebAssembly module drops a
+          test cube onto a static platform while the main thread renders the scene with Three.js. Use the
+          control button to pause or resume the simulation loop.
         </p>
-        <button id="action-button" type="button">Pause Spin</button>
+        <button id="action-button" type="button">Pause Simulation</button>
       </section>
     </main>
     <footer class="site-footer">

--- a/workers/physics.worker.js
+++ b/workers/physics.worker.js
@@ -1,0 +1,113 @@
+import RAPIER from 'https://cdn.jsdelivr.net/npm/@dimforge/rapier3d-compat@0.11.2/rapier.es.js';
+
+let world = null;
+let cubeBody = null;
+let running = false;
+let ready = false;
+let stepHandle = null;
+let pendingStart = false;
+
+async function initializeWorld() {
+  try {
+    await RAPIER.init();
+    const gravity = new RAPIER.Vector3(0, -9.81, 0);
+    world = new RAPIER.World(gravity);
+    world.timestep = 1 / 60;
+
+    const floorCollider = RAPIER.ColliderDesc.cuboid(6, 0.1, 6).setTranslation(0, -0.6, 0);
+    world.createCollider(floorCollider);
+
+    const bodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(0, 3, 0);
+    cubeBody = world.createRigidBody(bodyDesc);
+    const cubeCollider = RAPIER.ColliderDesc.cuboid(0.5, 0.5, 0.5).setRestitution(0.2);
+    world.createCollider(cubeCollider, cubeBody);
+
+    ready = true;
+    postMessage({
+      type: 'ready',
+      message: 'Rapier initialized in worker. Drop test prepared.'
+    });
+
+    if (pendingStart) {
+      setRunning(true);
+      pendingStart = false;
+    }
+  } catch (error) {
+    postMessage({
+      type: 'error',
+      message: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+function setRunning(next) {
+  if (!ready) {
+    pendingStart = pendingStart || next;
+    return;
+  }
+  if (running === next) {
+    return;
+  }
+  running = next;
+  if (running) {
+    if (stepHandle === null) {
+      stepHandle = setInterval(stepSimulation, 16);
+    }
+  } else if (stepHandle !== null) {
+    clearInterval(stepHandle);
+    stepHandle = null;
+  }
+  postMessage({ type: 'state', running });
+}
+
+function resetCube() {
+  if (!cubeBody) {
+    return;
+  }
+  cubeBody.setTranslation({ x: 0, y: 3, z: 0 }, true);
+  cubeBody.setLinvel({ x: 0, y: 0, z: 0 }, true);
+  cubeBody.setAngvel({ x: 0, y: 0, z: 0 }, true);
+}
+
+function stepSimulation() {
+  if (!world || !cubeBody) {
+    return;
+  }
+
+  world.step();
+
+  const translation = cubeBody.translation();
+  const rotation = cubeBody.rotation();
+
+  postMessage({
+    type: 'tick',
+    timestamp: performance.now(),
+    bodies: [
+      {
+        id: 'test-cube',
+        translation: { x: translation.x, y: translation.y, z: translation.z },
+        rotation: { x: rotation.x, y: rotation.y, z: rotation.z, w: rotation.w }
+      }
+    ]
+  });
+
+  if (translation.y < -10) {
+    resetCube();
+  }
+}
+
+self.addEventListener('message', (event) => {
+  const data = event.data;
+  if (!data || typeof data !== 'object') {
+    return;
+  }
+  if (data.type === 'start') {
+    setRunning(true);
+  } else if (data.type === 'pause') {
+    setRunning(false);
+  } else if (data.type === 'reset') {
+    resetCube();
+  }
+});
+
+initializeWorld();


### PR DESCRIPTION
## Summary
- load Rapier inside a dedicated module worker and broadcast cube transforms to the renderer
- hook the main thread to worker updates, add a ground mesh, and refresh the landing page copy
- mark Phase 1 checklist items complete in PLAN.md while deferring the optional shared-memory task

## Testing
- node --test
- npm run lint *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6b98f118832386fe1c6eb4ba33ee