### PR TITLE
Add generation viewer timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,6 +150,94 @@
             <dd id="stat-mean">—</dd>
           </div>
         </dl>
+        <section
+          id="generation-viewer"
+          class="generation-viewer is-empty"
+          aria-label="Generation viewer"
+        >
+          <header class="generation-viewer__header">
+            <div>
+              <h3>Generation Viewer</h3>
+              <p class="generation-viewer__subtitle">
+                Scrub through best-of generation stats or auto-play the evolution timeline.
+              </p>
+            </div>
+            <div class="generation-viewer__actions">
+              <button
+                id="generation-play"
+                class="generation-viewer__button"
+                type="button"
+                disabled
+              >
+                Play
+              </button>
+              <button
+                id="generation-latest"
+                class="generation-viewer__button generation-viewer__button--ghost"
+                type="button"
+                disabled
+              >
+                Latest
+              </button>
+            </div>
+          </header>
+          <label for="generation-slider" class="generation-viewer__label">Scrub generations</label>
+          <input
+            id="generation-slider"
+            class="generation-viewer__slider"
+            type="range"
+            min="0"
+            max="0"
+            step="1"
+            value="0"
+            disabled
+          />
+          <div class="generation-summary">
+            <div class="generation-summary__header">
+              <p class="generation-summary__title">
+                Generation <span id="generation-summary-generation">—</span>
+              </p>
+              <span id="generation-summary-count" class="generation-summary__count">0 / 0</span>
+            </div>
+            <p class="generation-summary__fitness">
+              Best fitness <span id="generation-summary-best">—</span>
+            </p>
+            <dl class="generation-summary__metrics">
+              <div>
+                <dt>Mean fitness</dt>
+                <dd id="generation-summary-mean">—</dd>
+              </div>
+              <div>
+                <dt>Displacement</dt>
+                <dd id="generation-summary-displacement">—</dd>
+              </div>
+              <div>
+                <dt>Avg speed</dt>
+                <dd id="generation-summary-speed">—</dd>
+              </div>
+              <div>
+                <dt>Avg height</dt>
+                <dd id="generation-summary-height">—</dd>
+              </div>
+              <div>
+                <dt>Upright time</dt>
+                <dd id="generation-summary-upright">—</dd>
+              </div>
+              <div>
+                <dt>Runtime</dt>
+                <dd id="generation-summary-runtime">—</dd>
+              </div>
+            </dl>
+          </div>
+          <ol
+            id="generation-timeline"
+            class="generation-timeline"
+            aria-label="Best fitness per generation"
+          ></ol>
+          <p class="generation-viewer__empty" role="status">
+            Launch an evolution run to populate the timeline.
+          </p>
+        </section>
       </section>
     </main>
     <footer class="site-footer">

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],
+  setupFilesAfterEnv: ['<rootDir>/tests/jest.setup.js'],
   transform: {
     '^.+\\.[tj]sx?$': 'babel-jest'
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,30 @@
         "eslint": "^9.8.0",
         "eslint-config-prettier": "^9.1.0",
         "globals": "^15.9.0",
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^30.2.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -1731,6 +1753,121 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
@@ -2066,6 +2203,228 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.2.0.tgz",
+      "integrity": "sha512-kazxw2L9IPuZpQ0mEt9lu9Z98SqR74xcagANmMBU16X0lS23yPc0+S6hGLUz8kVRlomZEs/5S/Zlpqwf5yu6OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.2.0",
+        "@jest/fake-timers": "30.2.0",
+        "@jest/types": "30.2.0",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.2.0",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/environment": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
+      "integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.2.0",
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "jest-mock": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/fake-timers": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
+      "integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@sinonjs/fake-timers": "^13.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.2.0",
+        "jest-mock": "30.2.0",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/types": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+      "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinclair/typebox": {
+      "version": "0.34.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/ci-info": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-message-util": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+      "integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.2.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.2.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-mock": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+      "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+      "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/expect": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
@@ -2125,6 +2484,30 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -2472,6 +2855,18 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2493,6 +2888,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2534,6 +2936,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -3061,6 +3473,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3078,6 +3518,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.0",
@@ -3157,6 +3604,19 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -3727,12 +4187,53 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -3742,6 +4243,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -3905,6 +4419,13 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -4195,6 +4716,225 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.2.0.tgz",
+      "integrity": "sha512-zbBTiqr2Vl78pKp/laGBREYzbZx9ZtqPjOK4++lL4BNDhxRnahg51HtoDrk9/VjIy9IthNEWdKVd7H5bqBhiWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.2.0",
+        "@jest/environment-jsdom-abstract": "30.2.0",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/environment": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
+      "integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.2.0",
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "jest-mock": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/fake-timers": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
+      "integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@sinonjs/fake-timers": "^13.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.2.0",
+        "jest-mock": "30.2.0",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/types": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+      "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
+      "version": "0.34.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/ci-info": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-message-util": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+      "integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.2.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.2.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-mock": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+      "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-util": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+      "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/pretty-format": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-node": {
@@ -4614,6 +5354,46 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4890,6 +5670,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5019,6 +5806,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -5309,6 +6109,33 @@
         "node": ">=10"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -5508,6 +6335,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -5522,6 +6356,26 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -5541,6 +6395,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/type-check": {
@@ -5686,6 +6566,19 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -5694,6 +6587,53 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -5760,6 +6700,45 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint": "^9.8.0",
     "eslint-config-prettier": "^9.1.0",
     "globals": "^15.9.0",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.2.0"
   }
 }

--- a/public/evolution/evolutionEngine.js
+++ b/public/evolution/evolutionEngine.js
@@ -146,17 +146,20 @@ export async function runEvolution({
       }
 
       evaluated.sort((a, b) => (b.fitness ?? 0) - (a.fitness ?? 0));
-      const bestFitness = evaluated[0]?.fitness ?? 0;
+      const bestEvaluation = evaluated[0] ?? null;
+      const bestFitness = bestEvaluation?.fitness ?? 0;
       const meanFitness =
         evaluated.reduce((total, entry) => total + (entry.fitness ?? 0), 0) /
         Math.max(1, evaluated.length);
-      const bestIndividual = evaluated[0] ? stripEvaluation(evaluated[0]) : null;
+      const bestIndividual = bestEvaluation ? stripEvaluation(bestEvaluation) : null;
+      const bestMetrics = bestEvaluation?.metrics ? clone(bestEvaluation.metrics) : null;
 
       const generationSummary = {
         generation,
         bestFitness,
         meanFitness,
-        bestIndividual
+        bestIndividual,
+        bestMetrics
       };
       history.push(clone(generationSummary));
 
@@ -167,6 +170,7 @@ export async function runEvolution({
           bestFitness,
           meanFitness,
           bestIndividual,
+          bestMetrics,
           evaluated: evaluated.map((entry) => ({
             id: entry.id,
             fitness: entry.fitness,

--- a/public/ui/generationViewer.js
+++ b/public/ui/generationViewer.js
@@ -1,0 +1,467 @@
+const DEFAULT_PLAY_INTERVAL = 1600;
+
+function cloneEntry(entry) {
+  return entry ? JSON.parse(JSON.stringify(entry)) : null;
+}
+
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function toNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function normalizeMetrics(metrics) {
+  if (!metrics || typeof metrics !== 'object') {
+    return null;
+  }
+  return {
+    displacement: isFiniteNumber(metrics.displacement) ? metrics.displacement : null,
+    averageSpeed: isFiniteNumber(metrics.averageSpeed) ? metrics.averageSpeed : null,
+    averageHeight: isFiniteNumber(metrics.averageHeight) ? metrics.averageHeight : null,
+    fallFraction: isFiniteNumber(metrics.fallFraction) ? metrics.fallFraction : null,
+    runtime: isFiniteNumber(metrics.runtime) ? metrics.runtime : null
+  };
+}
+
+function normalizeEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return {
+      generation: 0,
+      bestFitness: 0,
+      meanFitness: 0,
+      bestMetrics: null,
+      bestIndividual: null
+    };
+  }
+  const generation = toNumber(entry.generation, 0);
+  const bestFitness = isFiniteNumber(entry.bestFitness) ? entry.bestFitness : 0;
+  const meanFitness = isFiniteNumber(entry.meanFitness) ? entry.meanFitness : 0;
+  const bestMetrics = normalizeMetrics(entry.bestMetrics);
+  const bestIndividual = entry.bestIndividual ? cloneEntry(entry.bestIndividual) : null;
+  return {
+    generation,
+    bestFitness,
+    meanFitness,
+    bestMetrics,
+    bestIndividual
+  };
+}
+
+function formatDecimal(value, fractionDigits = 3) {
+  return isFiniteNumber(value) ? value.toFixed(fractionDigits) : '—';
+}
+
+function formatMeters(value) {
+  return isFiniteNumber(value) ? `${value.toFixed(2)} m` : '—';
+}
+
+function formatSpeed(value) {
+  return isFiniteNumber(value) ? `${value.toFixed(2)} m/s` : '—';
+}
+
+function formatPercent(value) {
+  return isFiniteNumber(value) ? `${Math.round(value * 100)}%` : '—';
+}
+
+function formatSeconds(value) {
+  return isFiniteNumber(value) ? `${value.toFixed(2)} s` : '—';
+}
+
+export function createGenerationViewer({
+  container,
+  slider,
+  playButton,
+  latestButton,
+  summary = {},
+  timeline
+} = {}) {
+  if (!container) {
+    throw new Error('createGenerationViewer requires a container element.');
+  }
+  if (!slider) {
+    throw new Error('createGenerationViewer requires a range input slider.');
+  }
+  if (!playButton) {
+    throw new Error('createGenerationViewer requires a play button.');
+  }
+  if (!latestButton) {
+    throw new Error('createGenerationViewer requires a latest button.');
+  }
+  if (!timeline) {
+    throw new Error('createGenerationViewer requires a timeline list element.');
+  }
+
+  const summaryNodes = {
+    generation: summary.generation ?? container.querySelector('#generation-summary-generation'),
+    count: summary.count ?? container.querySelector('#generation-summary-count'),
+    best: summary.best ?? container.querySelector('#generation-summary-best'),
+    mean: summary.mean ?? container.querySelector('#generation-summary-mean'),
+    displacement:
+      summary.displacement ?? container.querySelector('#generation-summary-displacement'),
+    speed: summary.speed ?? container.querySelector('#generation-summary-speed'),
+    height: summary.height ?? container.querySelector('#generation-summary-height'),
+    upright: summary.upright ?? container.querySelector('#generation-summary-upright'),
+    runtime: summary.runtime ?? container.querySelector('#generation-summary-runtime')
+  };
+
+  const emptyStateNode = container.querySelector('.generation-viewer__empty');
+
+  const state = {
+    entries: [],
+    indexByGeneration: new Map(),
+    selectedIndex: -1,
+    autoFollow: true,
+    running: false,
+    playing: false,
+    playTimer: null,
+    maxFitness: 0
+  };
+
+  const selectionListeners = new Set();
+  const timelineItems = [];
+
+  function stopPlayback() {
+    if (state.playTimer) {
+      clearInterval(state.playTimer);
+      state.playTimer = null;
+    }
+    if (state.playing) {
+      state.playing = false;
+      playButton.textContent = 'Play';
+      playButton.setAttribute('aria-pressed', 'false');
+    }
+  }
+
+  function setEmptyState(empty) {
+    container.classList.toggle('is-empty', empty);
+    if (emptyStateNode) {
+      emptyStateNode.hidden = !empty;
+    }
+  }
+
+  function updateMaxFitness() {
+    state.maxFitness = state.entries.reduce(
+      (max, entry) => Math.max(max, entry.bestFitness ?? 0),
+      0
+    );
+  }
+
+  function updateTimelineBars() {
+    const max = state.maxFitness > 0 ? state.maxFitness : 1;
+    timelineItems.forEach((record, index) => {
+      const entry = state.entries[index];
+      if (!record || !entry) {
+        return;
+      }
+      const ratio = entry.bestFitness > 0 ? Math.min(entry.bestFitness / max, 1) : 0;
+      const width = ratio > 0 ? Math.max(ratio * 100, 6) : 4;
+      if (record.bar) {
+        record.bar.style.width = `${width}%`;
+        record.bar.style.opacity = ratio > 0 ? '0.6' : '0.15';
+      }
+    });
+  }
+
+  function updateTimelineItem(index) {
+    const record = timelineItems[index];
+    const entry = state.entries[index];
+    if (!record || !entry) {
+      return;
+    }
+    if (record.labelGeneration) {
+      record.labelGeneration.textContent = `Gen ${entry.generation + 1}`;
+    }
+    if (record.labelFitness) {
+      record.labelFitness.textContent = formatDecimal(entry.bestFitness);
+    }
+  }
+
+  function updateTimelineActive() {
+    timelineItems.forEach((record, index) => {
+      if (!record) {
+        return;
+      }
+      const active = index === state.selectedIndex;
+      record.item.classList.toggle('is-active', active);
+      if (record.button) {
+        record.button.setAttribute('aria-pressed', active ? 'true' : 'false');
+      }
+    });
+  }
+
+  function updateSliderRange() {
+    const count = state.entries.length;
+    slider.min = '0';
+    slider.max = count > 0 ? String(count - 1) : '0';
+    const value = state.selectedIndex >= 0 ? state.selectedIndex : 0;
+    slider.value = String(value);
+    slider.disabled = count <= 1;
+    slider.setAttribute('aria-valuemin', '0');
+    slider.setAttribute('aria-valuemax', slider.max);
+    slider.setAttribute('aria-valuenow', slider.value);
+    slider.setAttribute(
+      'aria-valuetext',
+      count > 0 ? `Generation ${value + 1} of ${count}` : 'No generations yet'
+    );
+  }
+
+  function updateSummary() {
+    const entry = state.entries[state.selectedIndex] ?? null;
+    const count = state.entries.length;
+    if (summaryNodes.generation) {
+      summaryNodes.generation.textContent = entry ? `${entry.generation + 1}` : '—';
+    }
+    if (summaryNodes.count) {
+      summaryNodes.count.textContent = count > 0 ? `${state.selectedIndex + 1} / ${count}` : '0 / 0';
+    }
+    if (summaryNodes.best) {
+      summaryNodes.best.textContent = entry ? formatDecimal(entry.bestFitness) : '—';
+    }
+    if (summaryNodes.mean) {
+      summaryNodes.mean.textContent = entry ? formatDecimal(entry.meanFitness) : '—';
+    }
+    const metrics = entry?.bestMetrics ?? null;
+    if (summaryNodes.displacement) {
+      summaryNodes.displacement.textContent = metrics ? formatMeters(metrics.displacement) : '—';
+    }
+    if (summaryNodes.speed) {
+      summaryNodes.speed.textContent = metrics ? formatSpeed(metrics.averageSpeed) : '—';
+    }
+    if (summaryNodes.height) {
+      summaryNodes.height.textContent = metrics ? formatMeters(metrics.averageHeight) : '—';
+    }
+    if (summaryNodes.upright) {
+      const upright = metrics && isFiniteNumber(metrics.fallFraction)
+        ? 1 - metrics.fallFraction
+        : null;
+      summaryNodes.upright.textContent = metrics ? formatPercent(upright) : '—';
+    }
+    if (summaryNodes.runtime) {
+      summaryNodes.runtime.textContent = metrics ? formatSeconds(metrics.runtime) : '—';
+    }
+  }
+
+  function updateControls() {
+    const count = state.entries.length;
+    playButton.disabled = count <= 1;
+    latestButton.disabled = count === 0 || state.selectedIndex === count - 1;
+    if (state.playing && playButton.disabled) {
+      stopPlayback();
+    }
+  }
+
+  function selectIndex(index, { silent = false, user = false } = {}) {
+    if (state.entries.length === 0) {
+      state.selectedIndex = -1;
+      updateSliderRange();
+      updateSummary();
+      updateTimelineActive();
+      updateControls();
+      return;
+    }
+    const clamped = Math.min(Math.max(index, 0), state.entries.length - 1);
+    state.selectedIndex = clamped;
+    updateSliderRange();
+    updateSummary();
+    updateTimelineActive();
+    updateControls();
+    if (!silent) {
+      const payload = cloneEntry(state.entries[clamped]);
+      selectionListeners.forEach((listener) => listener(payload, { user }));
+    }
+  }
+
+  function createTimelineItem(entry) {
+    const item = document.createElement('li');
+    item.className = 'generation-timeline__item';
+    const buttonElement = document.createElement('button');
+    buttonElement.type = 'button';
+    buttonElement.className = 'generation-timeline__button';
+    const labelGeneration = document.createElement('span');
+    labelGeneration.className = 'generation-timeline__label generation-timeline__label--gen';
+    const labelFitness = document.createElement('span');
+    labelFitness.className = 'generation-timeline__label generation-timeline__label--fitness';
+    buttonElement.append(labelGeneration, labelFitness);
+    const bar = document.createElement('div');
+    bar.className = 'generation-timeline__bar';
+    buttonElement.addEventListener('click', () => {
+      stopPlayback();
+      const targetIndex = state.indexByGeneration.get(entry.generation);
+      state.autoFollow = targetIndex === state.entries.length - 1;
+      selectIndex(targetIndex ?? state.entries.length - 1, { user: true });
+    });
+    item.append(buttonElement, bar);
+    timeline.append(item);
+    return {
+      item,
+      button: buttonElement,
+      labelGeneration,
+      labelFitness,
+      bar
+    };
+  }
+
+  function addEntry(entry, { silent = false } = {}) {
+    const normalized = normalizeEntry(entry);
+    const existingIndex = state.indexByGeneration.has(normalized.generation)
+      ? state.indexByGeneration.get(normalized.generation)
+      : undefined;
+
+    if (typeof existingIndex === 'number' && existingIndex >= 0) {
+      state.entries[existingIndex] = normalized;
+      updateTimelineItem(existingIndex);
+      updateMaxFitness();
+      updateTimelineBars();
+      if (!silent && existingIndex === state.selectedIndex) {
+        updateSummary();
+      }
+      return existingIndex;
+    }
+
+    state.entries.push(normalized);
+    const index = state.entries.length - 1;
+    state.indexByGeneration.set(normalized.generation, index);
+    const record = createTimelineItem(normalized);
+    timelineItems.push(record);
+    updateTimelineItem(index);
+    updateMaxFitness();
+    updateTimelineBars();
+    setEmptyState(false);
+    if (state.autoFollow) {
+      selectIndex(index, { silent });
+    } else {
+      updateSliderRange();
+      updateControls();
+    }
+    return index;
+  }
+
+  function reset() {
+    stopPlayback();
+    state.entries = [];
+    state.indexByGeneration.clear();
+    state.selectedIndex = -1;
+    state.maxFitness = 0;
+    state.autoFollow = true;
+    timelineItems.splice(0, timelineItems.length);
+    timeline.innerHTML = '';
+    setEmptyState(true);
+    updateSliderRange();
+    updateSummary();
+    updateControls();
+    updateTimelineActive();
+  }
+
+  function setEntries(entries = []) {
+    reset();
+    if (Array.isArray(entries)) {
+      entries.forEach((entry) => {
+        addEntry(entry, { silent: true });
+      });
+    }
+    if (state.entries.length > 0) {
+      state.autoFollow = true;
+      selectIndex(state.entries.length - 1, { silent: true });
+      setEmptyState(false);
+    }
+  }
+
+  function jumpToLatest({ silent = false } = {}) {
+    if (state.entries.length === 0) {
+      return;
+    }
+    state.autoFollow = true;
+    selectIndex(state.entries.length - 1, { silent });
+  }
+
+  function startPlayback() {
+    if (state.entries.length <= 1 || state.playing) {
+      return;
+    }
+    state.playing = true;
+    playButton.textContent = 'Pause';
+    playButton.setAttribute('aria-pressed', 'true');
+    if (state.selectedIndex === state.entries.length - 1) {
+      selectIndex(0, { silent: true });
+    }
+    state.playTimer = setInterval(() => {
+      if (state.entries.length === 0) {
+        stopPlayback();
+        return;
+      }
+      const nextIndex = state.selectedIndex + 1;
+      if (nextIndex >= state.entries.length) {
+        stopPlayback();
+        jumpToLatest();
+        return;
+      }
+      selectIndex(nextIndex, { silent: false });
+    }, DEFAULT_PLAY_INTERVAL);
+  }
+
+  function setRunning(next) {
+    state.running = Boolean(next);
+    container.classList.toggle('is-running', state.running);
+  }
+
+  slider.addEventListener('input', () => {
+    if (state.entries.length === 0) {
+      return;
+    }
+    const index = Math.round(Number(slider.value) || 0);
+    state.autoFollow = index === state.entries.length - 1;
+    stopPlayback();
+    selectIndex(index, { user: true });
+  });
+
+  slider.addEventListener('pointerdown', () => {
+    state.autoFollow = false;
+    stopPlayback();
+  });
+
+  slider.addEventListener('touchstart', () => {
+    state.autoFollow = false;
+    stopPlayback();
+  });
+
+  playButton.addEventListener('click', () => {
+    if (state.playing) {
+      stopPlayback();
+    } else {
+      startPlayback();
+    }
+  });
+
+  latestButton.addEventListener('click', () => {
+    stopPlayback();
+    jumpToLatest();
+  });
+
+  setEmptyState(true);
+  updateSliderRange();
+  updateControls();
+
+  return {
+    reset,
+    setEntries,
+    addGeneration: addEntry,
+    jumpToLatest,
+    setRunning,
+    stopPlayback,
+    isPlaying() {
+      return state.playing;
+    },
+    onSelectionChange(callback) {
+      if (typeof callback === 'function') {
+        selectionListeners.add(callback);
+      }
+      return () => selectionListeners.delete(callback);
+    },
+    getSelectedEntry() {
+      return state.selectedIndex >= 0 ? cloneEntry(state.entries[state.selectedIndex]) : null;
+    }
+  };
+}

--- a/style.css
+++ b/style.css
@@ -203,6 +203,247 @@ h2 {
   font-weight: 600;
 }
 
+.generation-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1rem;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.generation-viewer.is-running {
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.35);
+}
+
+.generation-viewer.is-empty .generation-viewer__label,
+.generation-viewer.is-empty .generation-viewer__slider,
+.generation-viewer.is-empty .generation-summary,
+.generation-viewer.is-empty .generation-timeline,
+.generation-viewer.is-empty .generation-viewer__actions {
+  display: none;
+}
+
+.generation-viewer__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.generation-viewer__subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.generation-viewer__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button.generation-viewer__button {
+  padding: 0.4rem 0.9rem;
+  font-size: 0.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 189, 248, 0.5);
+  background: rgba(56, 189, 248, 0.15);
+  color: #e0f2fe;
+  box-shadow: none;
+}
+
+button.generation-viewer__button:hover {
+  background: rgba(56, 189, 248, 0.25);
+}
+
+button.generation-viewer__button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+button.generation-viewer__button--ghost {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.35);
+  color: rgba(226, 232, 240, 0.7);
+}
+
+button.generation-viewer__button--ghost:hover {
+  color: #e0f2fe;
+  border-color: rgba(56, 189, 248, 0.55);
+}
+
+.generation-viewer__label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.generation-viewer__slider {
+  width: 100%;
+  appearance: none;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(30, 41, 59, 0.85);
+  outline: none;
+}
+
+.generation-viewer__slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: #38bdf8;
+  border: 2px solid #0f172a;
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.35);
+}
+
+.generation-viewer__slider::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: #38bdf8;
+  border: 2px solid #0f172a;
+}
+
+.generation-summary {
+  border-radius: 12px;
+  padding: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.generation-summary__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.generation-summary__title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.generation-summary__count {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.generation-summary__fitness {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.generation-summary__fitness span {
+  font-weight: 600;
+  color: #38bdf8;
+}
+
+.generation-summary__metrics {
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.generation-summary__metrics dt {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.65);
+  margin: 0 0 0.2rem;
+}
+
+.generation-summary__metrics dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.generation-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.generation-timeline__item {
+  position: relative;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.4);
+  overflow: hidden;
+}
+
+.generation-timeline__item.is-active {
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.45);
+}
+
+button.generation-timeline__button {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  background: transparent;
+  color: inherit;
+  border: none;
+  box-shadow: none;
+  text-align: left;
+}
+
+button.generation-timeline__button:hover {
+  background: rgba(56, 189, 248, 0.1);
+}
+
+.generation-timeline__label {
+  pointer-events: none;
+}
+
+.generation-timeline__label--fitness {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.generation-timeline__bar {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.5), rgba(59, 130, 246, 0.2));
+  width: 0;
+  opacity: 0.6;
+  transition: width 180ms ease;
+  pointer-events: none;
+}
+
+.generation-viewer__empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.8);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border-radius: 10px;
+  padding: 0.75rem;
+  text-align: center;
+  display: block;
+}
+
+.generation-viewer.is-empty .generation-viewer__empty {
+  display: block;
+}
+
+.generation-viewer:not(.is-empty) .generation-viewer__empty {
+  display: none;
+}
+
 button {
   align-self: flex-start;
   padding: 0.65rem 1.25rem;

--- a/tests/generationViewer.test.js
+++ b/tests/generationViewer.test.js
@@ -1,0 +1,200 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { createGenerationViewer } from '../public/ui/generationViewer.js';
+
+function setupDom() {
+  document.body.innerHTML = `
+    <section id="generation-viewer" class="generation-viewer is-empty">
+      <header class="generation-viewer__header">
+        <div>
+          <h3>Generation Viewer</h3>
+          <p class="generation-viewer__subtitle">Testing</p>
+        </div>
+        <div class="generation-viewer__actions">
+          <button id="generation-play" class="generation-viewer__button" type="button" disabled>
+            Play
+          </button>
+          <button
+            id="generation-latest"
+            class="generation-viewer__button generation-viewer__button--ghost"
+            type="button"
+            disabled
+          >
+            Latest
+          </button>
+        </div>
+      </header>
+      <label for="generation-slider" class="generation-viewer__label">Scrub</label>
+      <input
+        id="generation-slider"
+        class="generation-viewer__slider"
+        type="range"
+        min="0"
+        max="0"
+        value="0"
+        disabled
+      />
+      <div class="generation-summary">
+        <div class="generation-summary__header">
+          <p class="generation-summary__title">
+            Generation <span id="generation-summary-generation">—</span>
+          </p>
+          <span id="generation-summary-count" class="generation-summary__count">0 / 0</span>
+        </div>
+        <p class="generation-summary__fitness">
+          Best fitness <span id="generation-summary-best">—</span>
+        </p>
+        <dl class="generation-summary__metrics">
+          <div><dt>Mean</dt><dd id="generation-summary-mean">—</dd></div>
+          <div><dt>Disp</dt><dd id="generation-summary-displacement">—</dd></div>
+          <div><dt>Speed</dt><dd id="generation-summary-speed">—</dd></div>
+          <div><dt>Height</dt><dd id="generation-summary-height">—</dd></div>
+          <div><dt>Upright</dt><dd id="generation-summary-upright">—</dd></div>
+          <div><dt>Runtime</dt><dd id="generation-summary-runtime">—</dd></div>
+        </dl>
+      </div>
+      <ol id="generation-timeline" class="generation-timeline"></ol>
+      <p class="generation-viewer__empty">Empty</p>
+    </section>
+  `;
+
+  const container = document.querySelector('#generation-viewer');
+  const slider = document.querySelector('#generation-slider');
+  const playButton = document.querySelector('#generation-play');
+  const latestButton = document.querySelector('#generation-latest');
+  const timeline = document.querySelector('#generation-timeline');
+  const summary = {
+    generation: document.querySelector('#generation-summary-generation'),
+    count: document.querySelector('#generation-summary-count'),
+    best: document.querySelector('#generation-summary-best'),
+    mean: document.querySelector('#generation-summary-mean'),
+    displacement: document.querySelector('#generation-summary-displacement'),
+    speed: document.querySelector('#generation-summary-speed'),
+    height: document.querySelector('#generation-summary-height'),
+    upright: document.querySelector('#generation-summary-upright'),
+    runtime: document.querySelector('#generation-summary-runtime')
+  };
+
+  const viewer = createGenerationViewer({
+    container,
+    slider,
+    playButton,
+    latestButton,
+    summary,
+    timeline
+  });
+
+  return {
+    viewer,
+    container,
+    slider,
+    playButton,
+    latestButton,
+    timeline,
+    summary
+  };
+}
+
+function createSampleEntry(overrides = {}) {
+  return {
+    generation: 0,
+    bestFitness: 1.234,
+    meanFitness: 0.8,
+    bestMetrics: {
+      displacement: 1.2,
+      averageSpeed: 0.6,
+      averageHeight: 0.9,
+      fallFraction: 0.15,
+      runtime: 3.5
+    },
+    ...overrides
+  };
+}
+
+describe('createGenerationViewer', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('initializes in an empty state with controls disabled', () => {
+    const { container, slider, playButton, latestButton } = setupDom();
+    expect(container.classList.contains('is-empty')).toBe(true);
+    expect(slider.disabled).toBe(true);
+    expect(playButton.disabled).toBe(true);
+    expect(latestButton.disabled).toBe(true);
+  });
+
+  it('adds generation entries and selects the latest by default', () => {
+    const { viewer, container, slider, playButton, latestButton, summary, timeline } = setupDom();
+
+    viewer.addGeneration(createSampleEntry({ generation: 0 }));
+
+    expect(container.classList.contains('is-empty')).toBe(false);
+    expect(slider.disabled).toBe(true);
+    expect(summary.best.textContent).toBe('1.234');
+    expect(summary.mean.textContent).toBe('0.800');
+    expect(summary.displacement.textContent).toBe('1.20 m');
+    expect(summary.speed.textContent).toBe('0.60 m/s');
+    expect(summary.height.textContent).toBe('0.90 m');
+    expect(summary.upright.textContent).toBe('85%');
+    expect(summary.runtime.textContent).toBe('3.50 s');
+    expect(timeline.children).toHaveLength(1);
+
+    viewer.addGeneration(
+      createSampleEntry({
+        generation: 1,
+        bestFitness: 2.5,
+        meanFitness: 1.1,
+        bestMetrics: {
+          displacement: 2.1,
+          averageSpeed: 1.1,
+          averageHeight: 1.2,
+          fallFraction: 0.05,
+          runtime: 3.8
+        }
+      })
+    );
+
+    expect(slider.disabled).toBe(false);
+    expect(slider.value).toBe('1');
+    expect(playButton.disabled).toBe(false);
+    expect(latestButton.disabled).toBe(true);
+    expect(summary.best.textContent).toBe('2.500');
+    expect(summary.displacement.textContent).toBe('2.10 m');
+    expect(timeline.children).toHaveLength(2);
+  });
+
+  it('updates an existing generation without duplicating timeline items', () => {
+    const { viewer, slider, summary, timeline } = setupDom();
+
+    viewer.addGeneration(createSampleEntry({ generation: 0 }));
+    viewer.addGeneration(
+      createSampleEntry({ generation: 0, bestFitness: 3.21, meanFitness: 2.1 })
+    );
+
+    expect(timeline.children).toHaveLength(1);
+    expect(slider.value).toBe('0');
+    expect(summary.best.textContent).toBe('3.210');
+    expect(summary.mean.textContent).toBe('2.100');
+  });
+
+  it('enables the latest button when scrubbing backwards', () => {
+    const { viewer, slider, latestButton } = setupDom();
+
+    viewer.addGeneration(createSampleEntry({ generation: 0 }));
+    viewer.addGeneration(createSampleEntry({ generation: 1, bestFitness: 2 }));
+
+    slider.value = '0';
+    slider.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(slider.value).toBe('0');
+    expect(latestButton.disabled).toBe(false);
+
+    latestButton.click();
+
+    expect(slider.value).toBe('1');
+    expect(latestButton.disabled).toBe(true);
+  });
+});

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -1,0 +1,9 @@
+const { TextEncoder, TextDecoder } = require('util');
+
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+}
+
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder;
+}


### PR DESCRIPTION
## Summary
- add a generation viewer panel with scrubber controls and metric readouts to the sidebar
- track best-of-generation metrics in the evolution loop and surface them through a reusable viewer module
- add targeted jsdom tests and supporting configuration to cover the new UI timeline behavior

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd951f3400832387301a556811f166