### PR TITLE
feat: add preview best button

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,7 @@
         </form>
         <div class="run-controls">
           <button id="evolution-start" type="button">Start Evolution</button>
+          <button id="preview-best" type="button" disabled>Preview Best</button>
           <progress id="evolution-progress" value="0" max="1" aria-live="polite"></progress>
         </div>
         <dl id="evolution-stats" class="stats-readout">


### PR DESCRIPTION
## Summary
- add a Preview Best control and track the top individual so the UI can trigger a physics preview
- allow the physics worker to respawn creatures using supplied morph and controller genomes for preview requests

## Testing
- npm run lint
- npx jest --config jest.config.cjs --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dd9b0945908323af13695d0473c09f