### PR TITLE
feat: expand arena with objective reward

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -485,11 +485,13 @@ physicsWorker.addEventListener('message', (event) => {
         const height = Number(summary.rootHeight ?? 0).toFixed(3);
         const contact = summary.footContact ? 'yes' : 'no';
         const angle = Number(summary.primaryJointAngle ?? 0).toFixed(3);
+        const objectiveDistance = Number(summary.objectiveDistance ?? 0).toFixed(3);
         console.info(
-          '[Sensors] height=%sm, contact=%s, jointAngle=%srad',
+          '[Sensors] height=%sm, contact=%s, jointAngle=%srad, objectiveDistance=%sm',
           height,
           contact,
-          angle
+          angle,
+          objectiveDistance
         );
         sensorLogTimestamp = data.timestamp;
       }

--- a/public/environment/arena.js
+++ b/public/environment/arena.js
@@ -1,0 +1,31 @@
+export const ARENA_HALF_EXTENTS = { x: 12, y: 0.1, z: 9 };
+export const ARENA_FLOOR_Y = -0.6;
+export const ARENA_SIZE = {
+  width: ARENA_HALF_EXTENTS.x * 2,
+  height: ARENA_HALF_EXTENTS.y * 2,
+  depth: ARENA_HALF_EXTENTS.z * 2
+};
+
+export const OBJECTIVE_HALF_EXTENTS = { x: 0.4, y: 0.4, z: 0.4 };
+export const OBJECTIVE_COLOR = '#22c55e';
+export const OBJECTIVE_POSITION = {
+  x: 8,
+  y: ARENA_FLOOR_Y + ARENA_HALF_EXTENTS.y + OBJECTIVE_HALF_EXTENTS.y,
+  z: 0
+};
+export const OBJECTIVE_SIZE = {
+  width: OBJECTIVE_HALF_EXTENTS.x * 2,
+  height: OBJECTIVE_HALF_EXTENTS.y * 2,
+  depth: OBJECTIVE_HALF_EXTENTS.z * 2
+};
+
+export function horizontalDistanceToObjective(point, objectivePosition = OBJECTIVE_POSITION) {
+  if (!point || typeof point !== 'object') {
+    return Math.hypot(objectivePosition.x, objectivePosition.z);
+  }
+  const x = Number(point.x ?? point[0]) || 0;
+  const z = Number(point.z ?? point[2]) || 0;
+  const dx = x - objectivePosition.x;
+  const dz = z - objectivePosition.z;
+  return Math.hypot(dx, dz);
+}

--- a/public/render/viewer.js
+++ b/public/render/viewer.js
@@ -12,6 +12,13 @@ import {
   WebGLRenderer
 } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
 import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+import {
+  ARENA_FLOOR_Y,
+  ARENA_SIZE,
+  OBJECTIVE_COLOR,
+  OBJECTIVE_POSITION,
+  OBJECTIVE_SIZE
+} from '../environment/arena.js';
 
 const META_DEFAULT_VERSION_INDEX = 0;
 const META_DEFAULT_WRITE_LOCK_INDEX = 1;
@@ -50,16 +57,32 @@ export function createViewer(canvas) {
   fillLight.position.set(-5, 2.5, -6);
   scene.add(ambient, keyLight, fillLight);
 
-  const groundGeometry = new BoxGeometry(16, 0.2, 12);
+  const groundGeometry = new BoxGeometry(ARENA_SIZE.width, ARENA_SIZE.height, ARENA_SIZE.depth);
   const groundMaterial = new MeshStandardMaterial({
     color: '#111827',
     roughness: 0.88,
     metalness: 0.04
   });
   const ground = new Mesh(groundGeometry, groundMaterial);
-  ground.position.y = -0.62;
+  ground.position.y = ARENA_FLOOR_Y - 0.02;
   ground.receiveShadow = false;
   scene.add(ground);
+
+  const objectiveGeometry = new BoxGeometry(
+    OBJECTIVE_SIZE.width,
+    OBJECTIVE_SIZE.height,
+    OBJECTIVE_SIZE.depth
+  );
+  const objectiveMaterial = new MeshStandardMaterial({
+    color: OBJECTIVE_COLOR,
+    roughness: 0.32,
+    metalness: 0.12
+  });
+  const objectiveMesh = new Mesh(objectiveGeometry, objectiveMaterial);
+  objectiveMesh.position.set(OBJECTIVE_POSITION.x, OBJECTIVE_POSITION.y, OBJECTIVE_POSITION.z);
+  objectiveMesh.castShadow = false;
+  objectiveMesh.receiveShadow = false;
+  scene.add(objectiveMesh);
 
   const dynamicBodiesRoot = new Group();
   scene.add(dynamicBodiesRoot);

--- a/tests/evolutionPhase4.test.js
+++ b/tests/evolutionPhase4.test.js
@@ -56,6 +56,24 @@ describe('computeLocomotionFitness', () => {
     expect(fastFitness.fitness).toBeGreaterThan(slowFitness.fitness);
   });
 
+  it('adds an objective reward when moving closer to the target cube', () => {
+    const towardObjective = [
+      { timestamp: 0, centerOfMass: { x: 0, y: 0.8, z: 0 }, rootHeight: 0.8 },
+      { timestamp: 1, centerOfMass: { x: 6.5, y: 0.82, z: 0 }, rootHeight: 0.82 }
+    ];
+    const awayFromObjective = [
+      { timestamp: 0, centerOfMass: { x: 0, y: 0.8, z: 0 }, rootHeight: 0.8 },
+      { timestamp: 1, centerOfMass: { x: -6.5, y: 0.82, z: 0 }, rootHeight: 0.82 }
+    ];
+
+    const towardFitness = computeLocomotionFitness(towardObjective);
+    const awayFitness = computeLocomotionFitness(awayFromObjective);
+
+    expect(towardFitness.displacement).toBeCloseTo(awayFitness.displacement, 5);
+    expect(towardFitness.objectiveReward).toBeGreaterThan(awayFitness.objectiveReward);
+    expect(towardFitness.fitness).toBeGreaterThan(awayFitness.fitness);
+  });
+
   it('detects prolonged loss of upright height even without ground contact', () => {
     const trace = [
       { timestamp: 0, centerOfMass: { x: 0, y: 0.8, z: 0 }, rootHeight: 0.8 },


### PR DESCRIPTION
## Summary
- enlarge the shared arena configuration and surface a visible objective cube
- update the physics worker and sensors to include the objective collider and distance data
- reward locomotion traces for approaching the objective and cover it with unit tests

## Testing
- npm test -- --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68dda6b72d6c8323af1410c93ad1b733