### PR TITLE
fix: keep evolution runs responsive

### DIFF
--- a/public/evolution/evolutionEngine.js
+++ b/public/evolution/evolutionEngine.js
@@ -1,5 +1,6 @@
 import { createRng, splitRng } from './rng.js';
 import { mutateCompositeGenome } from './mutation.js';
+import { yieldToMainThread } from './yield.js';
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
@@ -164,7 +165,7 @@ export async function runEvolution({
       history.push(clone(generationSummary));
 
       if (typeof onGeneration === 'function') {
-        onGeneration({
+        await onGeneration({
           generation: step,
           absoluteGeneration: generation,
           bestFitness,
@@ -178,6 +179,8 @@ export async function runEvolution({
           }))
         });
       }
+
+      await yieldToMainThread({ signal });
 
       if (typeof logger?.info === 'function') {
         logger.info(

--- a/public/evolution/simulator.js
+++ b/public/evolution/simulator.js
@@ -4,6 +4,7 @@ import { instantiateCreature } from './simulation/instantiateCreature.js';
 import { gatherSensorSnapshot } from './simulation/sensors.js';
 import { applyControllerCommands } from './simulation/controllerCommands.js';
 import { computeCenterOfMass } from './simulation/centerOfMass.js';
+import { yieldToMainThread } from './yield.js';
 
 function recordSample(instance, trace, timestamp, sensors) {
   const centerOfMass = computeCenterOfMass(instance);
@@ -53,6 +54,7 @@ export async function simulateLocomotion({
       const timestamp = (step + 1) * dt;
       if ((step + 1) % sampleSteps === 0 || step === totalSteps - 1) {
         recordSample(instance, trace, timestamp, sensors);
+        await yieldToMainThread({ signal });
       }
 
       if ((sensors.summary?.rootHeight ?? 0) < -2) {

--- a/public/evolution/yield.js
+++ b/public/evolution/yield.js
@@ -1,0 +1,40 @@
+const frameDuration = 16;
+
+function now() {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+function waitForNextFrame() {
+  if (typeof requestAnimationFrame === 'function') {
+    return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  }
+  return new Promise((resolve) => setTimeout(resolve, frameDuration));
+}
+
+/**
+ * Yields control back to the main thread so the browser can process UI work.
+ * Falls back to a short timeout when requestAnimationFrame is unavailable.
+ */
+export async function yieldToMainThread({ signal } = {}) {
+  if (signal?.aborted) {
+    return;
+  }
+  await waitForNextFrame();
+}
+
+export async function yieldIfLongRunning({
+  lastYieldTimestamp,
+  signal,
+  minInterval = frameDuration
+} = {}) {
+  const previous = lastYieldTimestamp ?? 0;
+  const current = now();
+  if (current - previous < minInterval) {
+    return previous;
+  }
+  await yieldToMainThread({ signal });
+  return now();
+}


### PR DESCRIPTION
## Summary
- add a shared helper to yield control back to the browser between long tasks
- await generation callbacks and yield after each generation so UI elements can refresh
- yield during locomotion sampling so the physics preview continues to animate

## Testing
- npm run lint *(fails: `npm` is not available in the execution environment)*
- node --test tests/*.test.js *(fails: `node` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb63cf77c8323af112836c6f63d31