### PR TITLE
Extend evolution runtime to 60 seconds

### DIFF
--- a/public/evolution/demo.js
+++ b/public/evolution/demo.js
@@ -52,7 +52,7 @@ export async function runEvolutionDemo(options = {}) {
     onStateSnapshot,
     resume,
     logger = console,
-    simulationDuration = 2.5,
+    simulationDuration = 60,
     simulationTimestep = 1 / 60,
     simulationSampleInterval = 1 / 30
   } = options;

--- a/public/evolution/simulator.js
+++ b/public/evolution/simulator.js
@@ -18,7 +18,7 @@ function recordSample(instance, trace, timestamp, sensors) {
 export async function simulateLocomotion({
   morphGenome,
   controllerGenome,
-  duration = 2.5,
+  duration = 60,
   timestep = 1 / 60,
   sampleInterval = 1 / 30,
   signal


### PR DESCRIPTION
## Summary
- increase the default simulation duration used by the locomotion simulator to 60 seconds
- propagate the longer simulation window to evolution runs via the demo orchestrator configuration

## Testing
- npm run lint
- node --test tests/*.test.js *(fails: Jest-style globals like `describe` are unavailable in the Node test runner)*
- npm test *(fails: local Jest setup cannot resolve `jest-environment-jsdom` and the `@dimforge/rapier3d-compat` module)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb8740be08323a69aa98c3f3f5c44