### PR TITLE
fix: reposition goal cube for preview camera

### DIFF
--- a/public/environment/arena.js
+++ b/public/environment/arena.js
@@ -9,7 +9,7 @@ export const ARENA_SIZE = {
 export const OBJECTIVE_HALF_EXTENTS = { x: 0.4, y: 0.4, z: 0.4 };
 export const OBJECTIVE_COLOR = '#22c55e';
 export const OBJECTIVE_POSITION = {
-  x: 8,
+  x: -8,
   y: ARENA_FLOOR_Y + ARENA_HALF_EXTENTS.y + OBJECTIVE_HALF_EXTENTS.y,
   z: 0
 };


### PR DESCRIPTION
## Summary
- move the arena objective cube to the opposite side so the default camera can see it

## Testing
- node --test tests/*.test.js *(fails: ReferenceError: describe is not defined)*
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68de2fc82cbc83239468c19ceccc4b84