### PR TITLE
feat: allow adding saved models to scene

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@
                 </p>
               </div>
               <div class="model-library__actions">
-                <button id="model-load" type="button" data-model-load disabled>Load</button>
+                <button id="model-add" type="button" data-model-add disabled>Add</button>
                 <button id="model-export" type="button" data-model-export disabled>Export</button>
                 <button
                   id="model-delete"

--- a/public/app.js
+++ b/public/app.js
@@ -485,23 +485,29 @@ if (modelLibraryContainer) {
     modelLibrary.clearName();
     updateStatus(`Saved model "${record.name}".`);
   });
-  modelLibrary.onLoad((id) => {
+  modelLibrary.onAdd((id) => {
     const record = loadModelRecord(id);
     if (!record) {
-      updateStatus('Unable to load the selected model.');
+      updateStatus('Unable to add the selected model.');
       return;
-    }
-    setLatestBestIndividual(record.individual);
-    if (record.config) {
-      applyConfigToForm(record.config);
-      applyStageFromConfig(record.config, { announce: false });
     }
     savedModelRecords = listModelRecords();
     modelLibrary.setModels(savedModelRecords);
     modelLibrary.setSelectedId(id);
-    previewIndividual(record.individual, {
-      message: `Loaded model "${record.name}". Previewing in physics viewer…`
+    const clone = deepClone(record.individual);
+    if (!clone) {
+      updateStatus('Unable to prepare the selected model for adding.');
+      return;
+    }
+    if (!physicsWorker || !workerReady) {
+      updateStatus('Physics worker is not ready yet.');
+      return;
+    }
+    physicsWorker.postMessage({
+      type: 'add-individual',
+      individual: clone
     });
+    updateStatus(`Added model "${record.name}" to the scene.`);
   });
   modelLibrary.onExport((id) => {
     const record = savedModelRecords.find((entry) => entry.id === id) ?? loadModelRecord(id);

--- a/public/ui/modelLibrary.js
+++ b/public/ui/modelLibrary.js
@@ -22,7 +22,7 @@ export function createModelLibrary({ container } = {}) {
   const nameInput = container.querySelector('[data-model-name]');
   const saveButton = container.querySelector('[data-model-save]');
   const list = container.querySelector('[data-model-list]');
-  const loadButton = container.querySelector('[data-model-load]');
+  const addButton = container.querySelector('[data-model-add]');
   const exportButton = container.querySelector('[data-model-export]');
   const deleteButton = container.querySelector('[data-model-delete]');
   const emptyState = container.querySelector('[data-model-empty]');
@@ -31,7 +31,7 @@ export function createModelLibrary({ container } = {}) {
     !nameInput ||
     !saveButton ||
     !list ||
-    !loadButton ||
+    !addButton ||
     !exportButton ||
     !deleteButton ||
     !emptyState
@@ -44,7 +44,7 @@ export function createModelLibrary({ container } = {}) {
   let selectedId = null;
 
   const saveListeners = new Set();
-  const loadListeners = new Set();
+  const addListeners = new Set();
   const deleteListeners = new Set();
   const exportListeners = new Set();
   const selectListeners = new Set();
@@ -58,7 +58,7 @@ export function createModelLibrary({ container } = {}) {
     const selectedOption = list.selectedOptions?.[0] ?? null;
     selectedId = selectedOption ? selectedOption.value : null;
     const hasSelection = Boolean(selectedId);
-    loadButton.disabled = !hasSelection;
+    addButton.disabled = !hasSelection;
     exportButton.disabled = !hasSelection;
     deleteButton.disabled = !hasSelection;
     if (selectedOption) {
@@ -113,15 +113,15 @@ export function createModelLibrary({ container } = {}) {
 
   list.addEventListener('dblclick', () => {
     if (selectedId) {
-      loadListeners.forEach((listener) => listener(selectedId));
+      addListeners.forEach((listener) => listener(selectedId));
     }
   });
 
-  loadButton.addEventListener('click', () => {
+  addButton.addEventListener('click', () => {
     if (!selectedId) {
       return;
     }
-    loadListeners.forEach((listener) => listener(selectedId));
+    addListeners.forEach((listener) => listener(selectedId));
   });
 
   exportButton.addEventListener('click', () => {
@@ -148,11 +148,11 @@ export function createModelLibrary({ container } = {}) {
       }
       return () => saveListeners.delete(callback);
     },
-    onLoad(callback = noop) {
+    onAdd(callback = noop) {
       if (typeof callback === 'function') {
-        loadListeners.add(callback);
+        addListeners.add(callback);
       }
-      return () => loadListeners.delete(callback);
+      return () => addListeners.delete(callback);
     },
     onDelete(callback = noop) {
       if (typeof callback === 'function') {


### PR DESCRIPTION
## Summary
- rename the saved models action to an Add button and expose an `onAdd` event from the library UI
- send added individuals to the physics worker so saved models spawn in the scene alongside the current preview
- update the physics worker to keep separate instances, allow creature-to-creature collisions, and handle the new add message

## Testing
- npm run lint
- node --test tests/*.test.js *(fails: tests expect global `describe` which is not provided by the Node test runner)*

------
https://chatgpt.com/codex/tasks/task_e_68de5116816883239518c11694f6ad43