### PR TITLE
Add clear stage control to remove models

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
               <option value="obstacle">Obstacle</option>
             </select>
             <button id="load-stage" type="button">Load Stage</button>
+            <button id="clear-stage" type="button">Clear Stage</button>
             <button id="simulation-toggle" type="button" aria-pressed="false">
               Pause Simulation
             </button>

--- a/public/render/viewer.js
+++ b/public/render/viewer.js
@@ -235,10 +235,11 @@ export function createViewer(canvas) {
       : [];
 
     sharedDescriptorMap = descriptorMap;
-    primaryBodyId = bodyIds[0] ?? primaryBodyId;
+    primaryBodyId = bodyIds[0] ?? null;
+    const hasDescriptors = descriptorMap.size > 0;
 
     sharedBodyMeshes.forEach((mesh, id) => {
-      mesh.visible = descriptorMap.size === 0 ? mesh.visible : descriptorMap.has(id);
+      mesh.visible = hasDescriptors ? descriptorMap.has(id) : false;
     });
   }
 

--- a/public/ui/viewControls.js
+++ b/public/ui/viewControls.js
@@ -1,6 +1,12 @@
 const noop = () => {};
 
-export function createViewControls({ select, button, stageSelect, stageButton } = {}) {
+export function createViewControls({
+  select,
+  button,
+  stageSelect,
+  stageButton,
+  stageClearButton
+} = {}) {
   if (!select) {
     throw new Error('createViewControls requires a select element.');
   }
@@ -13,6 +19,9 @@ export function createViewControls({ select, button, stageSelect, stageButton } 
   if (!stageButton) {
     throw new Error('createViewControls requires a stage load button.');
   }
+  if (!stageClearButton) {
+    throw new Error('createViewControls requires a stage clear button.');
+  }
 
   let currentMode = select.value || 'orbit';
   let simulationRunning = true;
@@ -21,6 +30,7 @@ export function createViewControls({ select, button, stageSelect, stageButton } 
   const toggleListeners = new Set();
   const stageChangeListeners = new Set();
   const stageLoadListeners = new Set();
+  const stageClearListeners = new Set();
 
   select.addEventListener('change', () => {
     currentMode = select.value || 'orbit';
@@ -38,6 +48,10 @@ export function createViewControls({ select, button, stageSelect, stageButton } 
 
   stageButton.addEventListener('click', () => {
     stageLoadListeners.forEach((listener) => listener(currentStage));
+  });
+
+  stageClearButton.addEventListener('click', () => {
+    stageClearListeners.forEach((listener) => listener(currentStage));
   });
 
   function setViewMode(mode) {
@@ -107,6 +121,12 @@ export function createViewControls({ select, button, stageSelect, stageButton } 
         stageLoadListeners.add(callback);
       }
       return () => stageLoadListeners.delete(callback);
+    },
+    onStageClear(callback = noop) {
+      if (typeof callback === 'function') {
+        stageClearListeners.add(callback);
+      }
+      return () => stageClearListeners.delete(callback);
     },
     setViewMode,
     setSimulationRunning,

--- a/workers/physics.worker.js
+++ b/workers/physics.worker.js
@@ -1050,6 +1050,16 @@ self.addEventListener('message', (event) => {
       setRunning(true);
     }
     postMessage({ type: 'stage-loaded', stageId: stage.id });
+  } else if (data.type === 'clear-stage-models') {
+    const wasRunning = running;
+    if (wasRunning) {
+      setRunning(false);
+    }
+    stopReplayPlayback({ notify: false });
+    clearCreature();
+    configureSharedState([], {});
+    syncSharedState();
+    postMessage({ type: 'stage-cleared' });
   } else if (data.type === 'preview-individual') {
     const individual =
       data.individual && typeof data.individual === 'object' ? data.individual : null;


### PR DESCRIPTION
## Summary
- add a Clear Stage button next to the Load Stage control and expose a clear-stage event from the view controls
- handle clear-stage messages in the app and physics worker to remove all models and update the viewer layout

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de5aa97bc8832389366f63ea5dd726