### PR TITLE
Remove prototype footer instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,12 +352,6 @@
         </form>
       </section>
     </main>
-    <footer class="site-footer">
-      <small>
-        Serve this directory with <code>python3 -m http.server 8080</code> and open
-        <code>http://localhost:8080/index.html</code> to explore the prototype.
-      </small>
-    </footer>
     <script type="module" src="./public/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the legacy footer guidance from the landing page

## Testing
- npm run lint
- node --test tests/*.test.js *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68de5dd42eac8323acaa7ff476bdd43a