### PR TITLE
fix: require ctrl key for canvas zoom

### DIFF
--- a/public/render/viewer.js
+++ b/public/render/viewer.js
@@ -51,6 +51,26 @@ export function createViewer(canvas) {
   controls.autoRotate = false;
   controls.target.set(0, 0.6, 0);
 
+  canvas.addEventListener(
+    'wheel',
+    (event) => {
+      if (event.ctrlKey) {
+        event.preventDefault();
+        return;
+      }
+      controls.enableZoom = false;
+      const restoreZoom = () => {
+        controls.enableZoom = true;
+      };
+      if (typeof queueMicrotask === 'function') {
+        queueMicrotask(restoreZoom);
+      } else {
+        Promise.resolve().then(restoreZoom);
+      }
+    },
+    { passive: false }
+  );
+
   const ambient = new AmbientLight('#e2e8f0', 0.6);
   const keyLight = new DirectionalLight('#60a5fa', 0.85);
   keyLight.position.set(6, 6.5, 4);


### PR DESCRIPTION
## Summary
- gate orbit viewer zoom so it only triggers when the user scrolls with the Ctrl key held
- prevent browser page zoom during Ctrl+scroll while keeping standard scrolling behaviour otherwise

## Testing
- npm run lint
- npm test
- node --test tests/*.test.js *(fails: tests are written for Jest and rely on describe being defined)*

------
https://chatgpt.com/codex/tasks/task_e_68de64bdc80483238e3b1529339be16d