### PR TITLE
fix: abort evolution runs immediately

### DIFF
--- a/tests/evolutionPhase4.test.js
+++ b/tests/evolutionPhase4.test.js
@@ -69,6 +69,29 @@ describe('simulateLocomotion', () => {
     expect(result.trace.length).toBeGreaterThan(0);
     expect(result.runtime).toBeGreaterThan(0);
   });
+
+  it('honors an explicit abort callback during simulation', async () => {
+    const morph = createDefaultMorphGenome();
+    const controller = createDefaultControllerGenome();
+    const abortError = new Error('stop-now');
+    let calls = 0;
+
+    await expect(
+      simulateLocomotion({
+        morphGenome: morph,
+        controllerGenome: controller,
+        duration: 2,
+        sampleInterval: 1 / 60,
+        shouldAbort: () => {
+          calls += 1;
+          if (calls > 5) {
+            throw abortError;
+          }
+        }
+      })
+    ).rejects.toBe(abortError);
+    expect(calls).toBeGreaterThan(5);
+  });
 });
 
 describe('morph genome mutations', () => {


### PR DESCRIPTION
## Summary
- propagate stop requests to the evolution worker through a shared abort flag so long-running evaluations halt promptly
- expose an optional abort hook in the locomotion simulator so simulations can exit mid-step when requested
- cover the simulator abort behaviour with a dedicated regression test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68de95b2a444832388f6a15cb4fd47c7