### PR TITLE
Fix limb collisions by keeping joint contacts enabled

### DIFF
--- a/genomes/morphGenome.js
+++ b/genomes/morphGenome.js
@@ -245,6 +245,14 @@ export function validateMorphGenome(genome) {
       } else {
         parentRefs.set(body.id, parentId);
       }
+      if (
+        Object.prototype.hasOwnProperty.call(body.joint, 'contactsEnabled') &&
+        typeof body.joint.contactsEnabled !== 'boolean'
+      ) {
+        errors.push(
+          `Joint on body "${body.id}" must specify contactsEnabled as a boolean when provided.`
+        );
+      }
       const axis = Array.isArray(body.joint.axis) ? body.joint.axis : [];
       if (axis.length !== 3) {
         errors.push(`Joint on body "${body.id}" requires a 3D axis vector.`);
@@ -404,6 +412,10 @@ export function buildMorphologyBlueprint(genome) {
         parentAnchor: toVector3(node.joint.parentAnchor, [0, 0, 0]),
         childAnchor: toVector3(node.joint.childAnchor, [0, 0, 0]),
         axis: toVector3(node.joint.axis, [0, 1, 0]),
+        contactsEnabled:
+          Object.prototype.hasOwnProperty.call(node.joint, 'contactsEnabled')
+            ? node.joint.contactsEnabled !== false
+            : true,
         limits:
           Array.isArray(node.joint.limits) && node.joint.limits.length === 2
             ? node.joint.limits.map((limit) => Number(limit) || 0)

--- a/tests/morphGenome.test.js
+++ b/tests/morphGenome.test.js
@@ -104,7 +104,8 @@ describe('buildMorphologyBlueprint', () => {
       expect.objectContaining({
         id: 'torso__leg',
         parentId: 'torso',
-        childId: 'leg'
+        childId: 'leg',
+        contactsEnabled: true
       })
     ]);
     const torso = blueprint.bodies.find((body) => body.id === 'torso');
@@ -133,6 +134,20 @@ describe('buildMorphologyBlueprint', () => {
     expect(blueprint.bodies).toHaveLength(0);
     expect(blueprint.joints).toHaveLength(0);
     expect(blueprint.materials).toEqual({});
+  });
+
+  it('allows genomes to request joint contact suppression', () => {
+    const genome = createDefaultMorphGenome();
+    genome.bodies[1].joint.contactsEnabled = false;
+
+    const blueprint = buildMorphologyBlueprint(genome);
+
+    expect(blueprint.joints).toEqual([
+      expect.objectContaining({
+        id: 'torso__leg',
+        contactsEnabled: false
+      })
+    ]);
   });
 });
 

--- a/workers/physics.worker.js
+++ b/workers/physics.worker.js
@@ -568,8 +568,9 @@ function instantiateCreature(morphGenome, controllerGenome, options = {}) {
       jointData = RAPIER.JointData.revolute(parentAnchor, childAnchor, axis);
     }
     const jointHandle = world.createImpulseJoint(jointData, parentEntry.body, childEntry.body, true);
+    const contactsEnabled = jointDef.contactsEnabled !== false;
     if (typeof jointHandle?.setContactsEnabled === 'function') {
-      jointHandle.setContactsEnabled(false);
+      jointHandle.setContactsEnabled(contactsEnabled);
     }
     if (jointDef.limits) {
       try {
@@ -584,6 +585,7 @@ function instantiateCreature(morphGenome, controllerGenome, options = {}) {
       parentId,
       childId,
       axis: [...jointDef.axis],
+      contactsEnabled,
       limits: jointDef.limits ? [...jointDef.limits] : null,
       handle: jointHandle
     };


### PR DESCRIPTION
## Summary
- default creature joints to keep contacts enabled so limbs can collide instead of clipping
- propagate the new contactsEnabled flag from genomes through the physics worker to joint descriptors
- validate and test the contactsEnabled option on morph genomes

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68deab408e308323baefbd1bce7a108e