### PR TITLE
fix: adjust additional spawn offsets to perpendicular line

### DIFF
--- a/workers/physics.worker.js
+++ b/workers/physics.worker.js
@@ -117,7 +117,7 @@ function computeInstanceOffset(index) {
   const spacing = 3;
   const step = Math.floor(index / 2) + 1;
   const direction = index % 2 === 0 ? 1 : -1;
-  return { x: direction * step * spacing, y: 0, z: 0 };
+  return { x: 0, y: 0, z: direction * step * spacing };
 }
 
 function cloneControllerBlueprintForInstance(blueprint, prefix) {


### PR DESCRIPTION
## Summary
- spawn additional creatures along the world Z axis so each new line is perpendicular to the previous X-axis placement

## Testing
- npm run lint
- node --test tests/*.test.js *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68decb9279548323b8ee06768e590aad