### PR TITLE
feat: extend arena objective distance

### DIFF
--- a/public/environment/arena.js
+++ b/public/environment/arena.js
@@ -1,4 +1,4 @@
-export const ARENA_HALF_EXTENTS = { x: 12, y: 0.1, z: 9 };
+export const ARENA_HALF_EXTENTS = { x: 20, y: 0.1, z: 9 };
 export const ARENA_FLOOR_Y = -0.6;
 export const ARENA_SIZE = {
   width: ARENA_HALF_EXTENTS.x * 2,
@@ -9,7 +9,7 @@ export const ARENA_SIZE = {
 export const OBJECTIVE_HALF_EXTENTS = { x: 0.4, y: 0.4, z: 0.4 };
 export const OBJECTIVE_COLOR = '#22c55e';
 export const OBJECTIVE_POSITION = {
-  x: -8,
+  x: -16,
   y: ARENA_FLOOR_Y + ARENA_HALF_EXTENTS.y + OBJECTIVE_HALF_EXTENTS.y,
   z: 0
 };

--- a/public/environment/stages.js
+++ b/public/environment/stages.js
@@ -4,7 +4,7 @@ export const DEFAULT_STAGE_ID = 'dash';
 
 const obstacleHalfExtents = { x: 0.9, y: 0.8, z: 1.8 };
 const obstaclePosition = {
-  x: -4,
+  x: -8,
   y: ARENA_FLOOR_Y + ARENA_HALF_EXTENTS.y + obstacleHalfExtents.y,
   z: 0
 };

--- a/tests/evolutionPhase4.test.js
+++ b/tests/evolutionPhase4.test.js
@@ -148,7 +148,8 @@ describe('computeLocomotionFitness', () => {
   it('adds an objective reward when moving closer to the target cube', () => {
     const startX = 0;
     const closerX = OBJECTIVE_POSITION.x + 1.5;
-    const fartherX = OBJECTIVE_POSITION.x + 14.5;
+    const travelDistance = Math.abs(startX - closerX);
+    const fartherX = startX + travelDistance;
 
     const towardObjective = [
       { timestamp: 0, centerOfMass: { x: startX, y: 0.8, z: 0 }, rootHeight: 0.8 },


### PR DESCRIPTION
## Summary
- extend the arena toward the objective so the reward cube sits twice as far from the spawn
- shift the obstacle-stage barrier to the new midpoint and update the fitness regression test to reflect the longer dash

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68deccb89bbc8323b7dc2676295a7e83