### PR TITLE
fix: enable CCD for creature bodies

### DIFF
--- a/workers/physics.worker.js
+++ b/workers/physics.worker.js
@@ -499,6 +499,7 @@ function instantiateCreature(morphGenome, controllerGenome, options = {}) {
 
   descriptors.forEach((descriptor) => {
     const bodyDesc = RAPIER.RigidBodyDesc.dynamic()
+      .setCcdEnabled(true)
       .setTranslation(descriptor.translation[0], descriptor.translation[1], descriptor.translation[2])
       .setRotation({
         x: descriptor.rotation[0],


### PR DESCRIPTION
## Summary
- enable continuous collision detection on all creature rigid bodies in the physics worker to reduce tunneling

## Testing
- npm run lint
- node --test tests/*.test.js *(fails: ReferenceError: describe is not defined in test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68def1c7e52083239cffb08c1986b3d4