### PR TITLE
fix: stabilize joint control impulses

### DIFF
--- a/public/physics/constants.js
+++ b/public/physics/constants.js
@@ -1,1 +1,2 @@
-export const MAX_JOINT_ANGULAR_DELTA = 2; // rad/s per simulation step
+export const MAX_JOINT_ANGULAR_DELTA = 0.4; // max change in relative angular speed per step (rad/s)
+export const MAX_JOINT_TARGET_SPEED = 6; // rad/s limit for joint controllers


### PR DESCRIPTION
## Summary
- clamp joint controller torque impulses to the delta needed to reach a bounded target speed
- lower the per-step angular change limit and introduce a maximum joint speed to reduce self-interpenetration

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68def0dcaacc8323bbff3da0160e911c