### PR TITLE
fix: prevent creature clipping instabilities

### DIFF
--- a/public/physics/ccd.js
+++ b/public/physics/ccd.js
@@ -1,0 +1,14 @@
+export function enableContinuousCollisionDetection(descriptor) {
+  if (!descriptor || typeof descriptor.setCcdEnabled !== 'function') {
+    return descriptor;
+  }
+  descriptor.setCcdEnabled(true);
+  return descriptor;
+}
+
+export function enableCcdOnDescriptors(...descriptors) {
+  descriptors.forEach((descriptor) => {
+    enableContinuousCollisionDetection(descriptor);
+  });
+  return descriptors;
+}

--- a/public/physics/stability.js
+++ b/public/physics/stability.js
@@ -1,0 +1,77 @@
+const DEFAULT_TIMESTEP = 1 / 60;
+const STABILITY_DEFAULTS = {
+  maxVelocityIterations: 12,
+  maxStabilizationIterations: 6,
+  allowedLinearError: 0.001,
+  allowedAngularError: 0.001,
+  predictionDistance: 0.002,
+  maxCcdSubsteps: 4
+};
+
+function clampMaximum(value, limit) {
+  if (!Number.isFinite(value)) {
+    return limit;
+  }
+  return Math.min(value, limit);
+}
+
+function clampMinimum(value, limit) {
+  if (!Number.isFinite(value)) {
+    return limit;
+  }
+  return Math.max(value, limit);
+}
+
+export function configureCreatureSimulationWorld(world) {
+  if (!world || typeof world !== 'object') {
+    return world;
+  }
+  const params = world.integrationParameters;
+  if (!params || typeof params !== 'object') {
+    if (!Number.isFinite(world.timestep) || world.timestep <= 0) {
+      world.timestep = DEFAULT_TIMESTEP;
+    }
+    return world;
+  }
+
+  const timestep = Number.isFinite(world.timestep) && world.timestep > 0
+    ? world.timestep
+    : DEFAULT_TIMESTEP;
+  world.timestep = timestep;
+  params.dt = Number.isFinite(params.dt) && params.dt > 0 ? params.dt : timestep;
+
+  params.maxVelocityIterations = clampMinimum(
+    params.maxVelocityIterations,
+    STABILITY_DEFAULTS.maxVelocityIterations
+  );
+  params.maxStabilizationIterations = clampMinimum(
+    params.maxStabilizationIterations,
+    STABILITY_DEFAULTS.maxStabilizationIterations
+  );
+
+  params.allowedLinearError = clampMaximum(
+    params.allowedLinearError,
+    STABILITY_DEFAULTS.allowedLinearError
+  );
+  params.allowedAngularError = clampMaximum(
+    params.allowedAngularError,
+    STABILITY_DEFAULTS.allowedAngularError
+  );
+  params.predictionDistance = clampMaximum(
+    params.predictionDistance,
+    STABILITY_DEFAULTS.predictionDistance
+  );
+  params.maxCcdSubsteps = clampMinimum(
+    params.maxCcdSubsteps,
+    STABILITY_DEFAULTS.maxCcdSubsteps
+  );
+
+  return world;
+}
+
+export function getStabilityDefaults() {
+  return {
+    timestep: DEFAULT_TIMESTEP,
+    ...STABILITY_DEFAULTS
+  };
+}

--- a/tests/physicsConfig.test.js
+++ b/tests/physicsConfig.test.js
@@ -1,0 +1,66 @@
+import { enableContinuousCollisionDetection } from '../public/physics/ccd.js';
+import {
+  configureCreatureSimulationWorld,
+  getStabilityDefaults
+} from '../public/physics/stability.js';
+
+describe('enableContinuousCollisionDetection', () => {
+  it('enables CCD when the descriptor supports it', () => {
+    const descriptor = { setCcdEnabled: jest.fn().mockReturnThis() };
+
+    const result = enableContinuousCollisionDetection(descriptor);
+
+    expect(descriptor.setCcdEnabled).toHaveBeenCalledWith(true);
+    expect(result).toBe(descriptor);
+  });
+
+  it('returns the original descriptor when CCD is unavailable', () => {
+    const descriptor = {};
+
+    const result = enableContinuousCollisionDetection(descriptor);
+
+    expect(result).toBe(descriptor);
+  });
+});
+
+describe('configureCreatureSimulationWorld', () => {
+  it('applies stability defaults to integration parameters', () => {
+    const params = {
+      dt: 0,
+      maxVelocityIterations: 4,
+      maxStabilizationIterations: 2,
+      allowedLinearError: 0.02,
+      allowedAngularError: 0.03,
+      predictionDistance: 0.05,
+      maxCcdSubsteps: 1
+    };
+    const world = { integrationParameters: params };
+
+    configureCreatureSimulationWorld(world);
+
+    const defaults = getStabilityDefaults();
+
+    expect(world.timestep).toBeCloseTo(defaults.timestep);
+    expect(params.dt).toBeCloseTo(defaults.timestep);
+    expect(params.maxVelocityIterations).toBeGreaterThanOrEqual(
+      defaults.maxVelocityIterations
+    );
+    expect(params.maxStabilizationIterations).toBeGreaterThanOrEqual(
+      defaults.maxStabilizationIterations
+    );
+    expect(params.allowedLinearError).toBeLessThanOrEqual(defaults.allowedLinearError);
+    expect(params.allowedAngularError).toBeLessThanOrEqual(defaults.allowedAngularError);
+    expect(params.predictionDistance).toBeLessThanOrEqual(defaults.predictionDistance);
+    expect(params.maxCcdSubsteps).toBeGreaterThanOrEqual(defaults.maxCcdSubsteps);
+  });
+
+  it('handles missing integration parameters gracefully', () => {
+    const world = {};
+
+    configureCreatureSimulationWorld(world);
+
+    const defaults = getStabilityDefaults();
+
+    expect(world.timestep).toBeCloseTo(defaults.timestep);
+  });
+});

--- a/workers/physics.worker.js
+++ b/workers/physics.worker.js
@@ -21,6 +21,8 @@ import {
   horizontalDistanceToObjective
 } from '../public/environment/arena.js';
 import { MAX_JOINT_ANGULAR_DELTA } from '../public/physics/constants.js';
+import { enableContinuousCollisionDetection } from '../public/physics/ccd.js';
+import { configureCreatureSimulationWorld } from '../public/physics/stability.js';
 import { DEFAULT_STAGE_ID, getStageDefinition } from '../public/environment/stages.js';
 
 function createInteractionGroup(membership, filter) {
@@ -509,6 +511,8 @@ function instantiateCreature(morphGenome, controllerGenome, options = {}) {
       .setLinearDamping(descriptor.linearDamping ?? 0.05)
       .setAngularDamping(descriptor.angularDamping ?? 0.08);
 
+    enableContinuousCollisionDetection(bodyDesc);
+
     const rigidBody = world.createRigidBody(bodyDesc);
     const colliderDesc = RAPIER.ColliderDesc.cuboid(
       descriptor.halfExtents[0],
@@ -519,6 +523,8 @@ function instantiateCreature(morphGenome, controllerGenome, options = {}) {
       .setFriction(descriptor.material?.friction ?? 0.9)
       .setRestitution(descriptor.material?.restitution ?? 0.2)
       .setCollisionGroups(COLLISION_GROUP_CREATURE);
+
+    enableContinuousCollisionDetection(colliderDesc);
     const collider = world.createCollider(colliderDesc, rigidBody);
 
     creatureBodies.set(descriptor.id, {
@@ -812,6 +818,7 @@ async function initializeWorld() {
     const gravity = new RAPIER.Vector3(0, -9.81, 0);
     world = new RAPIER.World(gravity);
     world.timestep = 1 / 60;
+    configureCreatureSimulationWorld(world);
 
     const floorCollider = RAPIER.ColliderDesc.cuboid(
       ARENA_HALF_EXTENTS.x,


### PR DESCRIPTION
## Summary
- enable continuous collision detection for creature rigid bodies and colliders
- tune Rapier integration parameters for more stable creature simulations
- cover the new physics helpers with unit tests

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68def0dcaacc8323bbff3da0160e911c